### PR TITLE
Support case sensitive filesystems

### DIFF
--- a/aegir.sh
+++ b/aegir.sh
@@ -28,7 +28,7 @@
   else
     #fresh installations of mac osx does not have /usr/local, so we need to create it first in case it's not there.
     printf "########\n# Checking /usr/local exists..\n"
-    if [ -d '/usr/local' ] ; then
+    if [ ! -d '/usr/local' ] ; then
       printf "# It doesn't so I'm creating it..\n"
       say "you may need to enter your password"
       sudo mkdir -p /usr/local


### PR DESCRIPTION
I prefer a case-sensitive file system, but doing that led to this error:

```
The directory /users/greggles/.drush does not exist.
Would you like to create it? (y/n): y
Directory / exists, but is not writable. Please check directory permissions.           [error]
Unable to create destination directory /users/greggles/.drush.                          [error]
```

It confused me for a while because I knew that ~/.drush did exist. And the error about / existing but not being writable seemed very weird. Then I put together that it's trying to create all of the directories starting at the top with /users as an alternate to /Users and it makes sense. 

I'm re-running the install now and will let you know how it goes.
